### PR TITLE
Feat: import from node modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "npm run clean && rollup -c",
     "build:watch": "npm run clean && rollup -c -w",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "postinstall": "npm run build"
   },
   "author": "gmfun",
   "license": "MIT"

--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,15 @@ export default function () {
     resolveId: function (importee, importer) {
       if (importee.indexOf('sass-variable-loader') >= 0 || importee.indexOf('variables') >= 0) {
         const importeeArray = importee.split('!');
-        var name = importeeArray[importeeArray.length - 1],
+        var name = importeeArray[importeeArray.length - 1];
+        var target
+
+        if (name.startsWith('.')) {
           target = path.resolve(path.dirname(importer), name);
+        } else {
+          var nodeModulesPath = __dirname.replace(/(.+node_modules)(.+)/, '$1')
+          target = path.resolve(path.join(nodeModulesPath, name))
+        }
 
         paths.set(target, name)
         return target


### PR DESCRIPTION
This modifications will allow to import `scss` variables from a `node_modules `folder.

This is useful when using a third-party `scss` library and you need to import some variables in order to customize some script.